### PR TITLE
Set all v3 Fallback oracles to 0

### DIFF
--- a/deployed-contracts/v3-mainnet/arbitrum.md
+++ b/deployed-contracts/v3-mainnet/arbitrum.md
@@ -26,7 +26,7 @@ _Pool_, _PoolConfigurator_, _Incentives_ and _Treasury_ addresses mentioned belo
 | TreasuryController            | [Github](https://github.com/aave/aave-v3-periphery/blob/master/contracts/treasury/CollectorController.sol)                            | 0xC3301b30f4EcBfd59dE0d74e89690C1a70C6f21B |
 | ParaswapLiquiditySwapAdapter  | [Github](https://github.com/aave/aave-v3-periphery/blob/master/contracts/adapters/paraswap/ParaSwapLiquiditySwapAdapter.sol)          | 0xAE9f94BD98eC2831a1330e0418bE0fDb5C95C2B9 |
 | ParaswapRepayAdapter          | [Github](https://github.com/aave/aave-v3-periphery/blob/master/contracts/adapters/paraswap/ParaSwapRepayAdapter.sol)                  | 0x32FdC26aFFA1eB331263Bcdd59F2e46eCbCC2E24 |
-| FallbackOracle                | [Github](https://github.com/aave/aave-v3-core/blob/master/contracts/mocks/oracle/PriceOracle.sol)                                     | 0x8aA68Ca9e25aAb6f9f41bF341d12Ab407AE099E2 |
+| FallbackOracle                | [Github](https://github.com/aave/aave-v3-core/blob/master/contracts/mocks/oracle/PriceOracle.sol)                                     | 0x0000000000000000000000000000000000000000 |
 
 ## Tokens
 

--- a/deployed-contracts/v3-mainnet/avalanche.md
+++ b/deployed-contracts/v3-mainnet/avalanche.md
@@ -24,7 +24,7 @@ _Pool_, _PoolConfigurator_, _Incentives_ and _Treasury_ addresses mentioned belo
 | TreasuryController            | [Github](https://github.com/aave/aave-v3-periphery/blob/master/contracts/treasury/CollectorController.sol)                    | 0xaCbE7d574EF8dC39435577eb638167Aca74F79f0 |
 | ParaSwapLiquiditySwapAdapter  | [Github](https://github.com/aave/aave-v3-periphery/blob/master/contracts/adapters/paraswap/ParaSwapLiquiditySwapAdapter.sol)  | 0xF7fC20D9D1D8DFE55F5F2c3180272a5747dD327F |
 | ParaSwapRepayAdapter          | [Github](https://github.com/aave/aave-v3-periphery/blob/master/contracts/adapters/paraswap/ParaSwapRepayAdapter.sol)          | 0x8a743090e9759E758d15a4CFd18408fb6332c625 |
-| FallbackOracle                | [Github](https://github.com/aave/aave-v3-core/blob/master/contracts/mocks/oracle/PriceOracle.sol)                             | 0x8aA68Ca9e25aAb6f9f41bF341d12Ab407AE099E2 |
+| FallbackOracle                | [Github](https://github.com/aave/aave-v3-core/blob/master/contracts/mocks/oracle/PriceOracle.sol)                             | 0x0000000000000000000000000000000000000000 |
 
 ## Tokens
 

--- a/deployed-contracts/v3-mainnet/fantom.md
+++ b/deployed-contracts/v3-mainnet/fantom.md
@@ -25,7 +25,7 @@ _Pool_, _PoolConfigurator_, _Incentives_ and _Treasury_ addresses mentioned belo
 | TreasuryController            | [Github](https://github.com/aave/aave-v3-periphery/blob/master/contracts/treasury/CollectorController.sol)                            | 0xc0F0cFBbd0382BcE3B93234E4BFb31b2aaBE36aD |
 | ParaswapRepayAdapter          | [Github](https://github.com/aave/aave-v3-periphery/blob/master/contracts/adapters/paraswap/ParaSwapRepayAdapter.sol)                  | 0x1408401B2A7E28cB747b3e258D0831Fc926bAC51 |
 | ParaswapLiquiditySwapAdapter  | [Github](https://github.com/aave/aave-v3-periphery/blob/master/contracts/adapters/paraswap/ParaSwapLiquiditySwapAdapter.sol)          | 0xe387c6053ce8ec9f8c3fa5ce085af73114a695d3 |
-| FallbackOracle                | [Github](https://github.com/aave/aave-v3-core/blob/master/contracts/mocks/oracle/PriceOracle.sol)                                     | 0x8aA68Ca9e25aAb6f9f41bF341d12Ab407AE099E2 |
+| FallbackOracle                | [Github](https://github.com/aave/aave-v3-core/blob/master/contracts/mocks/oracle/PriceOracle.sol)                                     | 0x0000000000000000000000000000000000000000 |
 
 ## Tokens
 

--- a/deployed-contracts/v3-mainnet/harmony.md
+++ b/deployed-contracts/v3-mainnet/harmony.md
@@ -22,7 +22,7 @@ _Pool_, _PoolConfigurator_, _Incentives_ and _Treasury_ addresses mentioned belo
 | AaveOracle                    | [Github](https://github.com/aave/aave-v3-core/blob/master/contracts/misc/AaveOracle.sol)                                      | 0x3C90887Ede8D65ccb2777A5d577beAb2548280AD |
 | Treasury                      | [Github](https://github.com/aave/aave-v3-periphery/blob/master/contracts/treasury/Collector.sol)                              | 0x8A020d92D6B119978582BE4d3EdFdC9F7b28BF31 |
 | TreasuryController            | [Github](https://github.com/aave/aave-v3-periphery/blob/master/contracts/treasury/CollectorController.sol)                    | 0xeaC16519923774Fd7723d3D5E442a1e2E46BA962 |
-| FallbackOracle                | [Github](https://github.com/aave/aave-v3-core/blob/master/contracts/mocks/oracle/PriceOracle.sol)                             | 0x8aA68Ca9e25aAb6f9f41bF341d12Ab407AE099E2 |
+| FallbackOracle                | [Github](https://github.com/aave/aave-v3-core/blob/master/contracts/mocks/oracle/PriceOracle.sol)                             | 0x0000000000000000000000000000000000000000 |
 
 ## Tokens
 

--- a/deployed-contracts/v3-mainnet/optimism.md
+++ b/deployed-contracts/v3-mainnet/optimism.md
@@ -24,7 +24,7 @@ _Pool_, _PoolConfigurator_, _Incentives_ and _Treasury_ addresses mentioned belo
 | AaveOracle                    | [Github](https://github.com/aave/aave-v3-core/blob/master/contracts/misc/AaveOracle.sol)                                              | 0xD81eb3728a631871a7eBBaD631b5f424909f0c77 |
 | Treasury                      | [Github](https://github.com/aave/aave-v3-periphery/blob/master/contracts/treasury/Collector.sol)                                      | 0xB2289E329D2F85F1eD31Adbb30eA345278F21bcf |
 | TreasuryController            | [Github](https://github.com/aave/aave-v3-periphery/blob/master/contracts/treasury/CollectorController.sol)                            | 0xA77E4A084d7d4f064E326C0F6c0aCefd47A5Cb21 |
-| FallbackOracle                | [Github](https://github.com/aave/aave-v3-core/blob/master/contracts/mocks/oracle/PriceOracle.sol)                                     | 0x8aA68Ca9e25aAb6f9f41bF341d12Ab407AE099E2 |
+| FallbackOracle                | [Github](https://github.com/aave/aave-v3-core/blob/master/contracts/mocks/oracle/PriceOracle.sol)                                     | 0x0000000000000000000000000000000000000000 |
 
 ## Tokens
 

--- a/deployed-contracts/v3-mainnet/polygon.md
+++ b/deployed-contracts/v3-mainnet/polygon.md
@@ -25,7 +25,7 @@ _Pool_, _PoolConfigurator_, _Incentives_ and _Treasury_ addresses mentioned belo
 | TreasuryController            | [Github](https://github.com/aave/aave-v3-periphery/blob/master/contracts/treasury/CollectorController.sol)                            | 0x73D435AFc15e35A9aC63B2a81B5AA54f974eadFe                                                                                    |
 | ParaSwapLiquiditySwapAdapter  | [Github](https://github.com/aave/aave-v3-periphery/blob/master/contracts/adapters/paraswap/ParaSwapLiquiditySwapAdapter.sol)          | 0x301F221bc732907E2da2dbBFaA8F8F6847c170c3                                                                                    |
 | ParaSwapRepayAdapter          | [Github](https://github.com/aave/aave-v3-periphery/blob/master/contracts/adapters/paraswap/ParaSwapRepayAdapter.sol)                  | 0xA125561fca253f19eA93970534Bb0364ea74187a                                                                                    |
-| FallbackOracle                | [Github](https://github.com/aave/aave-v3-core/blob/master/contracts/mocks/oracle/PriceOracle.sol)                                     | 0xaA5890362f36FeaAe91aF248e84e287cE6eCD1A9                                                                                    |
+| FallbackOracle                | [Github](https://github.com/aave/aave-v3-core/blob/master/contracts/mocks/oracle/PriceOracle.sol)                                     | 0x0000000000000000000000000000000000000000                                                                                    |
 
 ## Tokens
 

--- a/guides/governance-guide/parameterTuning.md
+++ b/guides/governance-guide/parameterTuning.md
@@ -2,20 +2,20 @@
 
 The Aave Pool in V3 has a variety of parameters which can be adjusted:
 
-- Asset Parameters
-- Bridge Parameters
+* Asset Parameters
+* Bridge Parameters
 
 This guide details the process of executing a proposal for parameter adjustments:
 
-- [ARC](https://www.notion.so/Asset-Listing-0ef43bf40ac845b7b94b66dfa4c4b3d6)
-- [AIP](https://www.notion.so/Asset-Listing-0ef43bf40ac845b7b94b66dfa4c4b3d6)
-- [Creating the proposal](https://www.notion.so/Asset-Listing-0ef43bf40ac845b7b94b66dfa4c4b3d6)
+* [ARC](https://www.notion.so/Asset-Listing-0ef43bf40ac845b7b94b66dfa4c4b3d6)
+* [AIP](https://www.notion.so/Asset-Listing-0ef43bf40ac845b7b94b66dfa4c4b3d6)
+* [Creating the proposal](https://www.notion.so/Asset-Listing-0ef43bf40ac845b7b94b66dfa4c4b3d6)
 
 ## ARC
 
 The ARC (Aave Request for Comment) is the first step in the proposal process. This is where the idea is proposed and the community can discuss. All ARCs should follow these standard [requirements](https://docs.aave.com/governance/arcs). In addition, parameter adjustments should include [asset risk analysis](https://docs.aave.com/risk/asset-risk/introduction) and rationale for changes. Here is a template which you can reference:
 
-- [Sample ARC from Gauntlet](https://governance.aave.com/t/arc-risk-parameter-updates-2022-01-14/6942)
+* [Sample ARC from Gauntlet](https://governance.aave.com/t/arc-risk-parameter-updates-2022-01-14/6942)
 
 ## AIP
 


### PR DESCRIPTION
Was following a discussion in LobsterDAO in regard to the upcoming merge and the effects on Aave & their oracles. 
The fallback oracle was mentioned and i knew that for v1 and v2 you guys stopped operating fallback oracles.
Checked the v3 contracts and saw that all of them were set to "0x0000000000000000000000000000000000000000" roughly 3 months ago, so these docs seem to be out of date. 

![image](https://user-images.githubusercontent.com/86656427/183222726-f4fce355-cca4-40d6-a4e7-dc0f64ce0b48.png)

I'll also create an issue for the [AaveOracle ](https://github.com/aave/docs-v3/blob/main/core-contracts/aaveoracle.md) section, since v3 fallback oracles also seem to be deprecated and no longer maintained.

![image](https://user-images.githubusercontent.com/86656427/183222787-1cd7956c-50f1-4bd4-9c9c-716605d1ebe4.png)
